### PR TITLE
Fixed a bug when using needsUpdate check in actionFactory

### DIFF
--- a/src/__test.js
+++ b/src/__test.js
@@ -156,4 +156,23 @@ describe('SimpleRedux', () => {
 
     expect(params).toEqual([true, true, true])
   })
+
+  test('action should not execute if needsUpdate is defined', async () => {
+    const simpleRedux = new SimpleRedux({ ...defaultConfig })
+    const store = createTestStore(simpleRedux.reducer)
+
+    const action = simpleRedux.actionFactory('action', {
+      needsUpdate: () => ({ test }) => {
+        expect(test).toBe(true)
+        return false
+      },
+      action: () => () => ({
+        test: false,
+      }),
+    })
+
+    await store.dispatch(action())
+
+    expect(store.getState()).toEqual({ test: true })
+  })
 })

--- a/src/action.js
+++ b/src/action.js
@@ -101,7 +101,7 @@ class Action {
     getState: Function,
     ...thunkParams: any
   ) => {
-    const isUnique = this.isUnique({ ...params }, getState)
+    const isUnique = this.isUnique(getState, { ...params })
     if (!isUnique) return Promise.resolve()
     this.dispatch.before({ dispatch, getState })
     try {

--- a/src/action.js
+++ b/src/action.js
@@ -10,8 +10,15 @@ class Action {
 
     this.config = config
     this.config.action = this.ensureThatActionIsAFunctionFactory(action)
-    before && (this.config.before = this.ensureThatActionIsAFunction(before))
-    after && (this.config.after = this.ensureThatActionIsAFunction(after))
+
+    if (before) {
+      this.config.before = this.ensureThatActionIsAFunction(before)
+    }
+
+    if (after) {
+      this.config.after = this.ensureThatActionIsAFunction(after)
+    }
+
     this.type = type
 
     const actionNames = this.getActionNames(type, config)


### PR DESCRIPTION
Using `needsUpdate` within the `simpleRedux.actionFactory` previously failed with an error message:

```
const action = simpleRedux.actionFactory('action', {
      needsUpdate: () => (state) => {
        return false
      },
      ...
    })
```

This is fixed now. A test has been added.